### PR TITLE
feat: add canonical standards triad and ticket template

### DIFF
--- a/standards/gates.md
+++ b/standards/gates.md
@@ -1,0 +1,108 @@
+# Gates — Catalog
+
+Every gate the delivery system enforces. A **gate** is a check that fires at a specific point in a ticket's lifecycle and either passes, blocks with a remediation, or records a flag for the grader rollup.
+
+This doc is the authoritative target for every implementation:
+- Jira-side: workflow validators + Automation rules satisfy these gates (see [`../rollout/jira-workflow-rules.md`](../rollout/jira-workflow-rules.md)).
+- Markdown-side: Claude Code pre-write hooks + CI satisfy these gates (see `product-management/.claude/`).
+
+Both implementations must emit the same [evidence codes](evidence-codes.md) for the same situations. All status values referenced here are `SCREAMING_SNAKE_CASE` per [`workflow.md`](workflow.md).
+
+---
+
+## Gate types
+
+- **D — Deterministic.** Field/section presence, git log check, enum membership, reference resolvability. Runs fast. Safe to block at transition time.
+- **J — Judge.** Claude reads text against a prompt from [`../prompts/`](../prompts/). Semantic. Slower and API-cost-incurring. Can block at transition OR run retrospectively.
+- **S — System-wide.** Requires scanning all tickets in the instance (e.g. WIP counts). Not per-ticket.
+- **R — Retrospective only.** Cannot fire at transition time (depends on post-transition data). Grader-only.
+
+---
+
+## Gate catalog
+
+### Commitment gates — fire on `DONE_SPECIFYING → READY`
+
+| Code | Name | Type | Check | Evidence codes |
+|---|---|---|---|---|
+| **C1** | Commitment transition exists | D | The transition is reaching `READY` from `DONE_SPECIFYING` (not a skip or backfill). | `COMMITMENT_TRANSITION_FOUND`, `COMMITMENT_TRANSITION_MISSING` |
+| **C3** | Gate approver recorded | D | `spec_approver` is populated, is in `authorized_approvers` for the project, and is not the `assignee`. | `APPROVER_RECORDED_AND_AUTHORIZED`, `APPROVER_FIELD_EMPTY`, `APPROVER_NOT_AUTHORIZED`, `APPROVER_IS_BUILDER` |
+| **C2** | BDD quality at commitment | J | Scenarios are Given/When/Then, cover the core rule (not just edge cases), not placeholder. Prompt: [`../prompts/C2.md`](../prompts/C2.md). | `SCENARIOS_COVER_CORE_RULE`, `SCENARIOS_COVER_ONLY_EDGE_CASES`, `SCENARIOS_PLACEHOLDER_OR_EMPTY`, `SCENARIOS_NOT_GIVEN_WHEN_THEN` |
+| **Y1** | Business Objective nameable | D+J | Section populated; judge evaluates whether stated in business terms. Prompt: [`../prompts/Y1.md`](../prompts/Y1.md). | See [`evidence-codes.md#Y1`](evidence-codes.md). |
+| **Y2** | Observable Impact describable | D+J | Section has metric + threshold + observation point. Prompt: [`../prompts/Y2.md`](../prompts/Y2.md). | See [`evidence-codes.md#Y2`](evidence-codes.md). |
+| **Y3** | AC in plain language, pre-commit | D+J | Section populated, written before `READY` (git timestamp), plain language. Prompt: [`../prompts/Y3b.md`](../prompts/Y3b.md). | See [`evidence-codes.md#Y3`](evidence-codes.md). |
+| **U12** | Risks surfaced | D | `Risks` section present and non-empty. `"None identified"` passes; blank/placeholder fails. | `RISKS_POPULATED`, `RISKS_EMPTY_OR_MISSING`, `RISKS_PLACEHOLDER` |
+
+### Commitment-adjacent — fire on `READY → IN_IMPLEMENTATION`
+
+| Code | Name | Type | Check | Evidence codes |
+|---|---|---|---|---|
+| **W1** | Spec workflow not bypassed | D | Prior status history for this ticket contains `DONE_SPECIFYING` and `READY` in order. Blocks direct jumps from any earlier state. | `WORKFLOW_COMPLETED`, `WORKFLOW_BYPASSED` |
+| **D2** | Design artifact for non-trivial work | D+J | If ticket is non-trivial (judge), `design_artifact_link` is populated. Prompt: [`../prompts/D2.md`](../prompts/D2.md). | `DESIGN_NOT_REQUIRED_WORK_TRIVIAL`, `DESIGN_PRESENT_AS_REQUIRED`, `DESIGN_MISSING_FOR_COMPLEX_WORK` |
+| **D7** | WIP respected | S | Count of tickets in `IN_IMPLEMENTATION` (per-assignee and system-wide) after this transition ≤ configured limits, OR `wip_exception` populated. | `WIP_WITHIN_LIMITS`, `WIP_EXCEEDED_PER_ENGINEER`, `WIP_EXCEEDED_SYSTEM` |
+
+### Build-complete gates — fire on `IN_IMPLEMENTATION → DONE_IMPLEMENTING`
+
+| Code | Name | Type | Check | Evidence codes |
+|---|---|---|---|---|
+| **D1** | Sub-tasks created after commit | D | All linked sub-task tickets have `created_at` ≥ the `READY → IN_IMPLEMENTATION` timestamp for this ticket. | `SUBTASKS_CREATED_POST_COMMIT`, `SUBTASKS_CREATED_PRE_COMMIT`, `SUBTASKS_ABSENT_ON_NON_TRIVIAL` |
+| **D4** | Sub-tasks closed | D | All linked sub-tasks have `status: DONE`. | `ALL_SUBTASKS_CLOSED_AT_DONE_IMPL`, `OPEN_SUBTASK_AT_DONE_IMPL` |
+| **D5** | Tests passing with evidence | D | A sub-task of type `TEST` is closed and has a `ci_runs` link resolving to a green run. | `TEST_SUBTASK_CLOSED_WITH_CI_LINK`, `TEST_SUBTASK_MISSING`, `TEST_SUBTASK_OPEN`, `TEST_SUBTASK_MISSING_CI_LINK` |
+| **D6** | Operationally shippable | D | `production_release_reference` populated with a URL that is not staging/localhost. | `DEPLOY_REFERENCE_PRESENT`, `DEPLOY_REFERENCE_EMPTY`, `DEPLOY_REFERENCE_LOCAL_ONLY` |
+
+### Done-gates — fire on `IN_VALIDATION → DONE`
+
+| Code | Name | Type | Check | Evidence codes |
+|---|---|---|---|---|
+| **Y4** | Non-builder validates | D | `validator` is populated and is not the `assignee`. | `VALIDATOR_INDEPENDENT`, `VALIDATOR_IS_BUILDER` |
+| **Y5** | Live in production at Done | D | `production_release_reference` is a production URL (not staging). | `PRODUCTION_REFERENCE_PRESENT_AT_DONE`, `PRODUCTION_REFERENCE_EMPTY`, `PRODUCTION_REFERENCE_STAGING_ONLY`, `PRODUCTION_REFERENCE_POST_DONE` |
+| **U10** | Impact measurement infrastructure | D | `impact_measurement_link` is populated and resolves (HTTP 2xx/3xx). | `IMPACT_LINK_PRESENT_AND_RESOLVABLE`, `IMPACT_LINK_UNREACHABLE`, `IMPACT_LINK_MISSING`, `IMPACT_LINK_BROKEN` |
+
+### Invariants — fire on any edit that violates
+
+| Code | Name | Type | Trigger | Check | Evidence codes |
+|---|---|---|---|---|---|
+| **U7** | No scope evolution after commitment | D | Edit to `Acceptance Criteria` or `Scenarios` body section | Current status must be ≤ `READY`. Editing these sections at `IN_IMPLEMENTATION` or later is a block. | `NO_POST_COMMIT_AC_EDITS`, `AC_EDITED_POST_COMMIT`, `SCENARIOS_EDITED_POST_COMMIT` |
+| **U8** | Validation outputs in contract | D | New ticket created that links to this one while this one is `IN_VALIDATION` | New ticket's `type` must be `STORY_DEFECT`. `STORY`, `TASK`, `BUG` created during validation fail. | `VALIDATION_OUTPUTS_IN_CONTRACT`, `NEW_STORY_CREATED_DURING_VALIDATION`, `NEW_TASK_CREATED_DURING_VALIDATION`, `NEW_BUG_CREATED_DURING_VALIDATION` |
+| **D10** | Backward transitions documented | D | Any backward status change | `reason_for_backward_move` populated on the same edit. | `FORWARD_ONLY_TRANSITIONS`, `BACKWARD_TRANSITION_DETECTED` |
+| **U11** | Correct issue-type classification | J | Any edit (ideally pre-`READY`) | Judge evaluates whether `type` matches content. Prompt: [`../prompts/U11.md`](../prompts/U11.md). | `TYPE_CORRECT`, `TYPE_MISMATCH` |
+
+### Retrospective only — no hook, grader-only
+
+| Code | Name | Type | Check |
+|---|---|---|---|
+| **Y6** | Completable in one cycle | R | Cycle time `READY → DONE_IMPLEMENTING` ≤ 7 calendar days. |
+| **U9** | Story defect classification | J/R | On `STORY_DEFECT` tickets, judge classifies as in-scope vs scope-evolution. Prompt: [`../prompts/U9.md`](../prompts/U9.md). |
+| **D3** | Violations surfaced, not absorbed | J/R | Judge evaluates whether deviations were documented vs silently absorbed. Prompt: [`../prompts/D3.md`](../prompts/D3.md). |
+| **D8** | Cycle time within norm | R | Per-engagement cycle-time distribution. |
+| **D9** | Story defect rate | R | Story Defects per N Stories. |
+
+---
+
+## Implementation notes
+
+### Ordering within a single edit
+
+When an edit touches multiple gates (e.g. moving to `READY` fires C1, C3, U12 deterministic and C2, Y1, Y2, Y3 judge), evaluate in this order:
+
+1. **Deterministic first.** If any fail, block with the failing-codes summary. Don't burn a judge call.
+2. **Judge next, in parallel if possible.** Each judge prompt runs independently. Aggregate results.
+3. **System-wide last.** WIP checks need the full tickets directory; run once at the end.
+
+### Block messaging
+
+Block messages must name the gate code, the evidence code, and the remediation. Example:
+
+```
+Blocked by C3 (APPROVER_FIELD_EMPTY).
+Moving to READY requires `spec_approver` populated with an authorized approver.
+Authorized for BBIT: jeffrey, yanna-proxy. See product-management/.claude/scripts/config.json.
+```
+
+### Versioning
+
+Adding a gate: minor bump. Changing an existing gate's check or evidence codes: breaking, requires prompt-version bump and migration note.
+
+### What is not a gate
+
+- Anything in [`system-rules.md`](system-rules.md) is an operating constraint. Many are enforced by gates (Rule 2 by W1/C1, Rule 3 by U7/U8, Rule 4 by D7); others are human discipline (Rule 1 single decision-maker, Rule 6 priority tradeoffs, Rule 11 pause on repeated ambiguity). Gates do not replace the rules; they enforce the ones that can be enforced mechanically.

--- a/standards/ticket-template.md
+++ b/standards/ticket-template.md
@@ -1,0 +1,120 @@
+# Ticket Template — Schema
+
+Canonical structure for a ticket in Nolte's delivery system. Applies to any implementation (Jira issues, markdown files in `product-management/tickets/`, or future substrates). When a ticket satisfies this schema and every gate in [`gates.md`](gates.md) that applies at its current status, it conforms.
+
+All machine-readable enum values (`status`, `type`, evidence codes) are `SCREAMING_SNAKE_CASE`. See [`workflow.md`](workflow.md) for the canonical enumerations and the display-label mapping.
+
+Source of truth. When an implementation disagrees with this file, the implementation is wrong.
+
+---
+
+## Frontmatter schema
+
+Every ticket carries structured metadata. In Jira, these are issue fields; in markdown, they are YAML frontmatter. Names are normative.
+
+### Always required
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Project-prefixed identifier, e.g. `BBIT-123`. Prefix matches `project`. |
+| `project` | string | Project code, e.g. `BBIT`, `SCPG`. |
+| `type` | enum | One of: `STORY`, `TASK`, `BUG`, `STORY_DEFECT`. Graded by U11. |
+| `status` | enum | One of the nine workflow statuses — see [`workflow.md`](workflow.md). |
+| `title` | string | One-line summary. |
+| `assignee` | string | The builder. Used by Y4 to ensure validator ≠ builder. |
+| `created_at` | ISO-8601 date | Ticket creation timestamp. |
+
+### Required at specific transitions
+
+| Field | Type | Required at | Graded by |
+|---|---|---|---|
+| `spec_approver` | string (user id) | `DONE_SPECIFYING → READY` | C3 |
+| `approved_at` | ISO-8601 date | `DONE_SPECIFYING → READY` | C3 |
+| `design_artifact_link` | URL | `IN_IMPLEMENTATION` entry if non-trivial | D2 |
+| `production_release_reference` | URL | `DONE_IMPLEMENTING` and `DONE` | D6, Y5 |
+| `impact_measurement_link` | URL | `DONE` | U10 |
+| `validator` | string (user id) | `DONE` | Y4 |
+
+### Required only for exceptional transitions
+
+| Field | Type | Description |
+|---|---|---|
+| `reason_for_backward_move` | string | Free text. Required when status moves backward. Graded by D10. |
+| `wip_exception` | string | Free text justification. Required when the transition would exceed the WIP limit. Graded by D7. |
+
+### Optional / derived
+
+| Field | Type | Description |
+|---|---|---|
+| `epic` | string (id) | Parent epic, if any. Y1 requires an epic link for Stories. |
+| `subtasks` | array of ticket ids | Links to sub-task tickets. D1/D4/D5 read these. |
+| `story_defects` | array of ticket ids | Links to `STORY_DEFECT` tickets filed against this ticket. |
+| `merged_prs` | array of URLs | Appended by engineering-repo automation on merge. |
+| `ci_runs` | array of URLs | Appended by engineering-repo automation on CI pass. |
+
+---
+
+## Body sections
+
+Five sections, in order. **Do not delete section headers.** If not applicable, write `"None identified"` or `"N/A — <reason>"` so the grader sees explicit intent rather than a missing section.
+
+### 1. Business Objective
+
+Link to Epic. Outcome in business terms: revenue, retention, activation, risk reduction, cost savings, time savings, compliance. Name the mechanism.
+
+Graded by **Y1**.
+
+Example: *"Reduce P50 claim intake time from 8min to <3min to handle 30% more claim volume without adding headcount."*
+
+### 2. Observable Impact
+
+One sentence. The metric, the threshold, and either the measurement location or the observability mechanism.
+
+Graded by **Y2**.
+
+Example: *"P50 claim intake time drops from 8min to <3min in Datadog dashboard X, observed within 2 weeks of release."*
+
+### 3. Acceptance Criteria
+
+Plain language. Verifiable by a non-engineer. Written before implementation.
+
+Graded by **Y3**.
+
+### 4. Scenarios
+
+BDD Given/When/Then covering the highest-value rules. Not every rule — the core behavior.
+
+Graded by **C2**.
+
+### 5. Risks
+
+Regulatory, technical, dependency, data. `"None identified"` is allowed and must be explicit. Blank is not.
+
+Graded by **U12**.
+
+---
+
+## Rules
+
+- **Never delete a section header.** The grader looks for each by name. A missing section fails that dimension.
+- **`"None identified"` is a valid answer** for Risks, and for Observable Impact when the work is a non-user-facing operational task. Not valid for Business Objective, AC, or Scenarios.
+- **Write AC before Scenarios, and both before commitment** (`DONE_SPECIFYING → READY`). Edits to these sections after commitment fail U7 (no scope evolution).
+- **For operational `TASK` tickets (rare):** only Business Objective and Observable Impact are required. AC and Scenarios may be minimal. Risks still required.
+- **Status changes are one concern per edit.** An edit that moves `status` should not also edit AC, Scenarios, or Risks. The gate will block mixed edits so the git history reflects one transition per commit.
+
+---
+
+## Versioning
+
+This schema is versioned. Breaking changes — renamed field, new required field, new section — require a PR here, prompt-version bump where judge prompts reference section names, and a migration note in any implementation that consumed the previous version.
+
+Additive changes — new optional field, new evidence code — are minor.
+
+---
+
+## Implementations
+
+- **Markdown (primary going forward):** `product-management/tickets/*.md`. YAML frontmatter uses `SCREAMING_SNAKE_CASE` enum values. Gates enforced by `.claude/` hooks pre-commit; grader reads git log for retrospective checks.
+- **Jira (legacy / bridge period):** fields created per [`../rollout/jira-fields-checklist.md`](../rollout/jira-fields-checklist.md); workflow rules per [`../rollout/jira-workflow-rules.md`](../rollout/jira-workflow-rules.md); template per [`../rollout/jira-template.md`](../rollout/jira-template.md). Jira uses the display-label column from [`workflow.md`](workflow.md#display-labels); the grader normalizes on read.
+
+Both implementations must satisfy every gate in [`gates.md`](gates.md) that applies at the ticket's current status.

--- a/standards/workflow.md
+++ b/standards/workflow.md
@@ -1,0 +1,155 @@
+# Workflow — State Graph and Transitions
+
+Canonical state graph for every ticket. Defines the nine statuses, legal transitions, and which [gates](gates.md) fire on each edge. Both Jira and markdown implementations conform to this graph — the only difference is substrate.
+
+All machine-readable status and type values are `SCREAMING_SNAKE_CASE`. Human display labels are mapped at the bottom of this doc.
+
+---
+
+## States
+
+| # | Status | Meaning |
+|---|---|---|
+| 1 | `BACKLOG` | Captured idea. No commitment to specify or build. |
+| 2 | `AWAITING_SPECIFICATION` | Picked for specification work. Not yet specified. |
+| 3 | `IN_SPECIFICATION` | Being specified. AC, Scenarios, Risks being drafted. |
+| 4 | `DONE_SPECIFYING` | Spec complete. Awaiting approver sign-off. |
+| 5 | `READY` | Approved. Committed. Waiting for implementation capacity. |
+| 6 | `IN_IMPLEMENTATION` | Actively being built. |
+| 7 | `DONE_IMPLEMENTING` | Build complete. Awaiting independent validation. |
+| 8 | `IN_VALIDATION` | Being validated by a non-builder against AC and Scenarios. |
+| 9 | `DONE` | Live in production. Impact observable. |
+
+---
+
+## Issue types
+
+Machine-readable values in `type` frontmatter field. `SCREAMING_SNAKE_CASE`:
+
+| Type | Meaning |
+|---|---|
+| `STORY` | User-facing delivery. 6-yes applies in full. |
+| `TASK` | Operational / non-user-facing work. Reduced schema (see [`ticket-template.md`](ticket-template.md)). |
+| `BUG` | Defect on already-released functionality. Not a validation output. |
+| `STORY_DEFECT` | Defect discovered during `IN_VALIDATION` of a parent Story. Must map to an existing Scenario (graded by U8, U9). |
+
+---
+
+## Legal transitions
+
+### Forward (the happy path)
+
+```
+BACKLOG
+  → AWAITING_SPECIFICATION
+    → IN_SPECIFICATION
+      → DONE_SPECIFYING
+        → READY              ← commitment gate (C1, C2, C3, Y1, Y2, Y3, U12)
+          → IN_IMPLEMENTATION ← W1 bypass check
+            → DONE_IMPLEMENTING ← D4, D5, D6
+              → IN_VALIDATION
+                → DONE        ← Y4, Y5, U10
+```
+
+### Backward (allowed, graded by D10)
+
+Any move from a later state to an earlier state is a **backward transition**. Always legal, always graded. Requires `reason_for_backward_move` populated on the same edit. Common valid backward moves:
+
+- `IN_IMPLEMENTATION → DONE_SPECIFYING` — "scope was wrong, needs re-spec"
+- `IN_VALIDATION → IN_IMPLEMENTATION` — "validation found a Story Defect"
+- `DONE_IMPLEMENTING → IN_IMPLEMENTATION` — "CI failure, needs a fix"
+
+### Illegal
+
+- **Skipping `DONE_SPECIFYING` or `READY` on the way to `IN_IMPLEMENTATION`.** This is the bypass W1 catches. Enforcement reverts the ticket to `AWAITING_SPECIFICATION` and posts a comment.
+- **`DONE_SPECIFYING → IN_IMPLEMENTATION` directly** — must pass through `READY`. The `READY` state is the commitment timestamp used by every downstream cycle-time calculation.
+- **`DONE → anything`.** Done tickets are final. Mistakes produce a follow-up ticket (new `id`), not a status change on the original.
+
+---
+
+## The commitment point
+
+`READY → IN_IMPLEMENTATION` is the **commitment point** and is a one-way door (System Rule 2). After entering `IN_IMPLEMENTATION`:
+
+- AC and Scenarios are frozen. Edits fail U7.
+- Capacity is allocated. New work cannot enter `IN_SPECIFICATION` or `IN_IMPLEMENTATION` if doing so would exceed WIP limits (System Rule 4; graded by D7).
+- Cycle time starts. `READY → DONE_IMPLEMENTING` measured against the 7-day norm (Y6, D8).
+
+The approver recorded in `spec_approver` at `DONE_SPECIFYING → READY` is the human accountable for that commitment (C3, System Rule 1).
+
+---
+
+## Validation discipline
+
+During `IN_VALIDATION`, per System Rule 3:
+
+- Validation confirms agreed behavior. It does not redefine it.
+- New ideas return to `BACKLOG` as new tickets, not edits to the one under validation (graded by U7, U8).
+- Story Defects may be filed as separate tickets (`type: STORY_DEFECT`) and must map to existing Scenarios (graded by U8, U9).
+
+---
+
+## Transition matrix — gates per edge
+
+Cross-reference: [`gates.md`](gates.md) has full gate definitions. This matrix answers "what fires when?" at a glance.
+
+| From → To | Deterministic gates | Judge gates |
+|---|---|---|
+| `BACKLOG → AWAITING_SPECIFICATION` | — | — |
+| `AWAITING_SPECIFICATION → IN_SPECIFICATION` | — | — |
+| `IN_SPECIFICATION → DONE_SPECIFYING` | — | — |
+| `DONE_SPECIFYING → READY` | C1, C3, U12 | C2, Y1, Y2, Y3 |
+| `READY → IN_IMPLEMENTATION` | W1, D1 (timing anchor), D7 (WIP), D2 (design artifact if non-trivial) | — |
+| `IN_IMPLEMENTATION → DONE_IMPLEMENTING` | D4, D5, D6, D7 | — |
+| `DONE_IMPLEMENTING → IN_VALIDATION` | — | — |
+| `IN_VALIDATION → DONE` | Y4, Y5, U10 | — |
+| *any* → *earlier* (backward) | D10 | — |
+| edits to AC / Scenarios while `status >= IN_IMPLEMENTATION` | U7 | — |
+| new ticket linked to this one while in `IN_VALIDATION` | U8 | U9 (on the new ticket if `type: STORY_DEFECT`) |
+
+Gates evaluated retrospectively by the grader only (never at transition): Y6, D8, D9, D3, U11.
+
+---
+
+## WIP limits and exceptions
+
+WIP limits are set in the implementation's config (for markdown: `product-management/.claude/scripts/config.json`). Default norms:
+
+- **`IN_SPECIFICATION`** — 2 per specifier
+- **`IN_IMPLEMENTATION`** — 1 per engineer, 6 system-wide
+- **`IN_VALIDATION`** — 3 system-wide
+
+Transitions that would exceed a limit are blocked unless the edit also populates `wip_exception` with a justification (System Rule 4, graded by D7). Exceptions are logged in git history and rolled up monthly.
+
+---
+
+## Display labels
+
+Machine values above are canonical. When rendering for humans — PR comments, rollup reports, Jira bridge — map to these display labels. The mapping is the single place the two conventions meet.
+
+| Machine value | Display label |
+|---|---|
+| `BACKLOG` | Backlog |
+| `AWAITING_SPECIFICATION` | Awaiting Specification |
+| `IN_SPECIFICATION` | In Specification |
+| `DONE_SPECIFYING` | Done Specifying |
+| `READY` | Ready |
+| `IN_IMPLEMENTATION` | In Implementation |
+| `DONE_IMPLEMENTING` | Done Implementing |
+| `IN_VALIDATION` | In Validation |
+| `DONE` | Done |
+| `STORY` | Story |
+| `TASK` | Task |
+| `BUG` | Bug |
+| `STORY_DEFECT` | Story Defect |
+
+The Jira implementation uses the display-label column as its workflow status names. The markdown implementation uses the machine-value column in frontmatter. Grader output uses machine values; UI layers (PR comments, rollup tables) render display labels.
+
+---
+
+## Implementations
+
+- **Markdown:** status is a YAML frontmatter field with `SCREAMING_SNAKE_CASE` value. Transitions are commits that edit it. Gates run as pre-write hooks on `tickets/*.md`.
+- **Jira:** status is workflow state using the display label. Transitions are Jira transitions. Gates run as workflow validators and Automation rules — see [`../rollout/jira-workflow-rules.md`](../rollout/jira-workflow-rules.md). The grader normalizes Jira status names to machine values on read.
+
+Both must accept exactly the forward / backward transitions above and fire exactly the gates in the matrix.

--- a/template/ticket.md
+++ b/template/ticket.md
@@ -1,0 +1,72 @@
+---
+# Always required — see standards/ticket-template.md
+id: PROJ-000                       # Project-prefixed identifier (prefix matches `project`)
+project: PROJ                      # Project code, e.g. BBIT, SCPG
+type: STORY                        # STORY | TASK | BUG | STORY_DEFECT
+status: BACKLOG                    # See standards/workflow.md for the nine statuses
+title: One-line summary of the delivery
+assignee: unassigned               # The builder. Validator (Y4) must be different.
+created_at: 2026-01-01             # ISO-8601
+
+# Parent / structure
+epic: null                         # Required for STORY (Y1)
+subtasks: []                       # Populated as sub-task tickets are created
+story_defects: []                  # Links to STORY_DEFECT tickets filed against this one
+
+# Required at specific transitions — leave null until the transition
+spec_approver: null                # C3 — required at DONE_SPECIFYING → READY
+approved_at: null                  # C3 — required at DONE_SPECIFYING → READY
+design_artifact_link: null         # D2 — required at IN_IMPLEMENTATION entry if non-trivial
+production_release_reference: null # D6, Y5 — required at DONE_IMPLEMENTING and DONE
+impact_measurement_link: null      # U10 — required at DONE
+validator: null                    # Y4 — required at DONE; must not equal `assignee`
+
+# Exceptional transitions only
+reason_for_backward_move: null     # D10 — free text, required on any backward status move
+wip_exception: null                # D7 — free text, required when transition exceeds WIP limit
+
+# Appended by automation — do not edit by hand
+merged_prs: []
+ci_runs: []
+---
+
+## Business Objective
+
+<!-- Graded by Y1. Link to Epic. Outcome in business terms: revenue, retention,
+     activation, risk reduction, cost savings, time savings, compliance. Name the mechanism.
+     "None identified" is NOT valid here. -->
+
+_Example: Reduce P50 claim intake time from 8min to <3min to handle 30% more claim volume without adding headcount._
+
+## Observable Impact
+
+<!-- Graded by Y2. One sentence. The metric, the threshold, and either the measurement
+     location or the observability mechanism.
+     "None identified" allowed only for non-user-facing operational TASK tickets. -->
+
+_Example: P50 claim intake time drops from 8min to <3min in Datadog dashboard X, observed within 2 weeks of release._
+
+## Acceptance Criteria
+
+<!-- Graded by Y3. Plain language. Verifiable by a non-engineer. Written BEFORE implementation.
+     Editing this section after commitment (DONE_SPECIFYING → READY) fails U7. -->
+
+- When ..., then ...
+- When ..., then ...
+
+## Scenarios
+
+<!-- Graded by C2. BDD Given/When/Then covering the highest-value rules — not every rule.
+     Written before commitment. -->
+
+Given ...
+When ...
+Then ...
+And ...
+
+## Risks
+
+<!-- Graded by U12. Regulatory, technical, dependency, data.
+     "None identified" is allowed and must be explicit. Blank is not. -->
+
+- ...


### PR DESCRIPTION
Standards (source of truth — implementations must conform):
- standards/workflow.md: nine-status state graph with transition rules, SCREAMING_SNAKE_CASE enums, and display-label mapping for Jira bridge
- standards/gates.md: full enforcement catalog (18 gates) tied to each status transition, with the grader dimension each gate backs
- standards/ticket-template.md: canonical ticket schema — frontmatter fields (always-required, transition-gated, exceptional, derived), five body sections (Business Objective, Observable Impact, AC, Scenarios, Risks), and the rules governing edits and versioning

Template (copy-pasteable starter derived from the schema):
- template/ticket.md: frontmatter grouped by when each field is required (always, transition-gated, exceptional, automation-appended) with inline comments citing the grading dimension. Body carries all five sections in spec order with rule reminders.